### PR TITLE
make gem dependency less restrictive

### DIFF
--- a/lib/mas/cms/client/version.rb
+++ b/lib/mas/cms/client/version.rb
@@ -1,7 +1,7 @@
 module Mas
   module Cms
     module Client
-      VERSION = '1.1.0'.freeze
+      VERSION = '1.2.0'.freeze
     end
   end
 end

--- a/mas-cms-client.gemspec
+++ b/mas-cms-client.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activemodel', '~> 4.2', '>= 4.2.7'
-  spec.add_runtime_dependency 'activesupport', '~> 4.2', '>= 4.2.7'
+  spec.add_runtime_dependency 'activemodel', '~> 4.2'
+  spec.add_runtime_dependency 'activesupport', '~> 4.2'
   spec.add_runtime_dependency 'faraday', '~> 0.9.2'
   spec.add_runtime_dependency 'faraday-conductivity', '~> 0.3.1'
   spec.add_runtime_dependency 'faraday_middleware', '~> 0.10.0'


### PR DESCRIPTION
The dependency on ActiveModel and ActiveSupport to at least 4.2.7 was conflicting with the gem dependency versions in  rad-consumer. Setting the dependency to 4.2 enables rad-consumer to use this cms gem.