### PR TITLE
[DEV APPROVED] - 8612 Improve Categories API on MAS CMS gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The gems supports the following types:
   * Article
   * Action Plan
   * Corporate
+  * Category
   * News
   * Video
   * Home Page
@@ -99,6 +100,9 @@ Mas::Cms::ActionPlan.find('next-steps-if-you-cant-get-a-mortgage')
 
 Mas::Cms::Corporate.find('media-comment--money-mental-health-missing-link-report')
 # GET /api/en/action_plans/next-steps-if-you-cant-get-a-mortgage.json
+
+Mas::Cms::Category.find('pensions-and-retirement')
+# GET /api/en/categories/pensions-and-retirement.json
 
 Mas::Cms::News.find('new-rules-could-make-it-harder-to-get-a-payday-loan')
 # GET /api/en/news/new-rules-could-make-it-harder-to-get-a-payday-loan.json

--- a/lib/mas/cms/connection.rb
+++ b/lib/mas/cms/connection.rb
@@ -64,10 +64,8 @@ module Mas
         yield blk
       rescue Faraday::Error::ResourceNotFound
         raise Errors::ResourceNotFound
-
       rescue Faraday::Error::ConnectionFailed
         raise Errors::ConnectionFailed
-
       rescue Faraday::Error::ClientError => error
         case error.response[:status]
         when 422

--- a/lib/mas/cms/entity/category.rb
+++ b/lib/mas/cms/entity/category.rb
@@ -9,15 +9,15 @@ module Mas::Cms
     class << self
       def resource_attributes(response_body, options = {})
         body = response_body.dup
-        body[:contents] = build_contents(body[:contents], options)
-        body[:legacy_contents] = build_contents(body[:legacy_contents], options)
+        body['contents'] = build_contents(body['contents'], options)
+        body['legacy_contents'] = build_contents(body['legacy_contents'], options)
         body
       end
 
       private
 
       def build_contents(contents, options)
-        return [] unless contents.present?
+        return [] if contents.blank?
 
         contents.map do |item|
           klass = content_item_type_to_entity_class.fetch(item['type'], Other)
@@ -32,6 +32,7 @@ module Mas::Cms
       def content_item_type_to_entity_class
         {
           nil           => Category,
+          'category'    => Category,
           'guide'       => Article,
           'action_plan' => ActionPlan,
           'article'     => Article,

--- a/mas-cms-client.gemspec
+++ b/mas-cms-client.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'mas/cms/client/version'
@@ -15,11 +16,10 @@ Gem::Specification.new do |spec|
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
-  end
+  warning = 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
+  raise warning unless spec.respond_to?(:metadata)
+
+  spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'

--- a/spec/factories/category.rb
+++ b/spec/factories/category.rb
@@ -13,7 +13,7 @@ FactoryGirl.define do
       type 'category'
 
       trait :content_items do
-        contents { %w(article_hash action_plan_hash).map(&method(:build)) }
+        contents { %w[article_hash action_plan_hash].map(&method(:build)) }
       end
 
       initialize_with do

--- a/spec/mas/cms/attribute_builder_spec.rb
+++ b/spec/mas/cms/attribute_builder_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require 'mas/cms/repository/cms/attribute_builder'
 
 module Mas::Cms::Repository::CMS

--- a/spec/mas/cms/config_spec.rb
+++ b/spec/mas/cms/config_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Mas::Cms::Config do
     config.cache_gets   = cache_gets
   end
 
-  [:timeout, :open_timeout, :host, :api_token, :retries, :cache, :cache_gets].each do |attr|
+  %i[timeout open_timeout host api_token retries cache cache_gets].each do |attr|
     it "responds to `#{attr}`" do
       expect(config.send(attr)).to eq send(attr)
     end

--- a/spec/mas/cms/entity/entity_spec.rb
+++ b/spec/mas/cms/entity/entity_spec.rb
@@ -2,7 +2,7 @@ module Mas::Cms
   RSpec.describe Entity, type: :model do
     subject { described_class.new(double, attributes) }
 
-    let(:attributes) { Hash.new }
+    let(:attributes) { {} }
 
     it { is_expected.to have_read_only_attributes(:id) }
 

--- a/spec/mas/cms/entity/home_page_spec.rb
+++ b/spec/mas/cms/entity/home_page_spec.rb
@@ -3,10 +3,10 @@ module Mas::Cms
     it_has_behavior 'a cms page entity'
     subject { described_class.new(double, attributes) }
 
-    let(:attributes) { Hash.new }
+    let(:attributes) { {} }
 
     it 'has correct attributes' do
-      [:promo_banner_url, :promo_banner_url].each do |attr|
+      %i[promo_banner_url promo_banner_url].each do |attr|
         expect(subject).to respond_to(attr)
       end
     end

--- a/spec/mas/cms/entity/video_spec.rb
+++ b/spec/mas/cms/entity/video_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Mas::Cms::Video, type: :model do
       title: 'awesome-title',
       description: 'awesome-description',
       body: 'awesome-body',
-      categories: [:foo, :bar],
+      categories: %i[foo bar],
       alternates: [:cy]
     }
   end
@@ -18,7 +18,7 @@ RSpec.describe Mas::Cms::Video, type: :model do
 
   describe 'attributes' do
     it 'are set' do
-      %i(type title description body categories alternates).each do |attr|
+      %i[type title description body categories alternates].each do |attr|
         expect(subject.public_send(attr)).to eql(params[attr])
       end
     end


### PR DESCRIPTION
**Target Process ticket**: _supports_ [TP#8612](https://moneyadviceservice.tpondemand.com/entity/8612)

**Summary**
This work was done to support an [on-going work](https://github.com/moneyadviceservice/frontend/compare/8612_pensions-webchat?expand=1) for displaying the TPAS(The Pension Advice Service) pension banner in the _Pensions and Retirement_ category. 

**Checklist**
+ [x] Tests passed.
+ [x] Rubocop is passing for this PR (or any other lint like JShint).
+ [x] Commit history reviewed (clear commit messages).
