### PR TITLE
[DEV APPROVED] 8664 Add article preview client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :test do
   gem 'faker', '~> 1.6'
   gem 'rake', '~> 12.0'
   gem 'rspec', '~> 3.0'
-  gem 'rubocop', '~> 0.47'
+  gem 'rubocop'
   gem 'shoulda-matchers', '~> 3.1'
   gem 'vcr', '~> 3.0.3'
   gem 'webmock', '~> 2.1'

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Every page has its own type.
 The gems supports the following types:
 
   * Article
+  * Article Preview
   * Action Plan
   * Corporate
   * Category
@@ -94,6 +95,9 @@ Some examples of how to retrieve data from the CMS are given below.
 ```ruby
 Mas::Cms::Article.find('how-to-apply-for-a-mortgage')
 # GET /api/en/articles/how-to-apply-for-a-mortgage.json
+
+Mas::Cms::ArticlePreview.find('how-to-apply-for-a-mortgage')
+# GET /api/preview/en/how-to-apply-for-a-mortgage.json
 
 Mas::Cms::ActionPlan.find('next-steps-if-you-cant-get-a-mortgage')
 # GET /api/en/action_plans/next-steps-if-you-cant-get-a-mortgage.json

--- a/lib/mas/cms.rb
+++ b/lib/mas/cms.rb
@@ -13,6 +13,7 @@ module Mas
 
     autoload :ActionPlan, 'mas/cms/entity/action_plan'
     autoload :Article, 'mas/cms/entity/article'
+    autoload :ArticlePreview, 'mas/cms/entity/article_preview'
     autoload :ArticleLink, 'mas/cms/entity/article_link'
     autoload :Category, 'mas/cms/entity/category'
     autoload :Clump, 'mas/cms/entity/clump'

--- a/lib/mas/cms/entity/article_preview.rb
+++ b/lib/mas/cms/entity/article_preview.rb
@@ -1,0 +1,14 @@
+module Mas::Cms
+  class ArticlePreview < Article
+    def self.path(slug:, locale:)
+      [
+        api_prefix,
+        'preview',
+        locale,
+        slug
+      ].compact
+        .join('/')
+        .downcase + '.json'
+    end
+  end
+end

--- a/spec/factories/category.rb
+++ b/spec/factories/category.rb
@@ -13,7 +13,7 @@ FactoryGirl.define do
       type 'category'
 
       trait :content_items do
-        contents { %w[article_hash action_plan_hash].map(&method(:build)) }
+        contents { %w(article_hash action_plan_hash).map(&method(:build)) }
       end
 
       initialize_with do

--- a/spec/mas/cms/config_spec.rb
+++ b/spec/mas/cms/config_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Mas::Cms::Config do
     config.cache_gets   = cache_gets
   end
 
-  %i[timeout open_timeout host api_token retries cache cache_gets].each do |attr|
+  %i(timeout open_timeout host api_token retries cache cache_gets).each do |attr|
     it "responds to `#{attr}`" do
       expect(config.send(attr)).to eq send(attr)
     end

--- a/spec/mas/cms/entity/article_preview_spec.rb
+++ b/spec/mas/cms/entity/article_preview_spec.rb
@@ -1,0 +1,18 @@
+module Mas::Cms
+  RSpec.describe ArticlePreview, type: :model do
+    it_has_behavior 'a cms page entity'
+    subject { described_class.new(double, attributes) }
+
+    it { expect(described_class.superclass).to be(Mas::Cms::Article) }
+
+    describe '.path' do
+      subject(:path) do
+        described_class.path(slug: 'foo', locale: 'en')
+      end
+
+      it 'returns article preview path' do
+        expect(path).to eq('/api/preview/en/foo.json')
+      end
+    end
+  end
+end

--- a/spec/mas/cms/entity/home_page_spec.rb
+++ b/spec/mas/cms/entity/home_page_spec.rb
@@ -6,7 +6,7 @@ module Mas::Cms
     let(:attributes) { {} }
 
     it 'has correct attributes' do
-      %i[promo_banner_url promo_banner_url].each do |attr|
+      %i(promo_banner_url promo_banner_url).each do |attr|
         expect(subject).to respond_to(attr)
       end
     end

--- a/spec/mas/cms/entity/video_spec.rb
+++ b/spec/mas/cms/entity/video_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Mas::Cms::Video, type: :model do
       title: 'awesome-title',
       description: 'awesome-description',
       body: 'awesome-body',
-      categories: %i[foo bar],
+      categories: %i(foo bar),
       alternates: [:cy]
     }
   end
@@ -18,7 +18,7 @@ RSpec.describe Mas::Cms::Video, type: :model do
 
   describe 'attributes' do
     it 'are set' do
-      %i[type title description body categories alternates].each do |attr|
+      %i(type title description body categories alternates).each do |attr|
         expect(subject.public_send(attr)).to eql(params[attr])
       end
     end


### PR DESCRIPTION
https://moneyadviceservice.tpondemand.com/entity/8664

## Problem

On the CMS, when the editors are changing one article, they have the possibility to preview the article. This preview feature is implemented on the site [here](https://github.com/moneyadviceservice/frontend/blob/master/app/controllers/articles_preview_controller.rb#L5)

## Solution

Today the gem don't support previewing articles hence this PR. This PR includes the client communication when the editors are previewing the article before publishing it.

This is to support the work of replacing the old code with the gem.

## Before

This is the old code:

https://github.com/moneyadviceservice/frontend/blob/master/app/controllers/articles_preview_controller.rb#L5
https://github.com/moneyadviceservice/frontend/blob/master/lib/core/interactor/article_previewer.rb
https://github.com/moneyadviceservice/frontend/blob/master/lib/core/entity/article.rb
https://github.com/moneyadviceservice/frontend/blob/master/lib/core/interactor/article_reader.rb
https://github.com/moneyadviceservice/frontend/blob/master/lib/core/interactor/base_content_reader.rb
https://github.com/moneyadviceservice/frontend/blob/master/lib/core/repository/cms/preview.rb
https://github.com/moneyadviceservice/frontend/blob/master/lib/core/repository/cms/preview.rb

## After

That turns into:

```
Mas::Cms::ArticlePreview.find('how-to-apply-for-a-mortgage')
```