### PR TITLE
8803 fix issue where null response could not be processed

### DIFF
--- a/lib/mas/cms/client/version.rb
+++ b/lib/mas/cms/client/version.rb
@@ -1,7 +1,7 @@
 module Mas
   module Cms
     module Client
-      VERSION = '1.5.0'.freeze
+      VERSION = '1.5.1'.freeze
     end
   end
 end

--- a/lib/mas/cms/connection.rb
+++ b/lib/mas/cms/connection.rb
@@ -17,7 +17,7 @@ module Mas
           faraday.request :retry, max: config.retries
           faraday.request :user_agent, app: 'Mas-Cms-Client', version: Mas::Cms::Client::VERSION
           faraday.response :raise_error
-          faraday.response :json
+          faraday.response :json, parser_options: { quirks_mode: true }
           faraday.use :instrumentation
           faraday.token_auth config.api_token
           faraday.adapter Faraday.default_adapter
@@ -30,8 +30,8 @@ module Mas
         with_exception_support do
           request = ->(_) { raw_connection.get(path) }
           response = fetch_from_cache_or_request(path, cached, &request)
-
           raise HttpRedirect.new(response) if HttpRedirect.redirect?(response)
+          raise Errors::ResourceNotFound if response.body.nil?
           response
         end
       end

--- a/mas-cms-client.gemspec
+++ b/mas-cms-client.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activesupport', '~> 4.2'
   spec.add_runtime_dependency 'faraday', '~> 0.9.2'
   spec.add_runtime_dependency 'faraday-conductivity', '~> 0.3.1'
-  spec.add_runtime_dependency 'faraday_middleware', '~> 0.10.0'
+  spec.add_runtime_dependency 'faraday_middleware', '~> 0.12.2'
   spec.add_runtime_dependency 'rubytree', '~> 0.9.7'
 end

--- a/spec/mas/cms/connection_spec.rb
+++ b/spec/mas/cms/connection_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Mas::Cms::Connection do
 
   describe '.get' do
     let(:path)     { '/test/me.json' }
-    let(:response) { double(status: status, headers: {}) }
+    let(:response) { double(status: status, headers: {}, body: {}) }
     let(:status)   { 200 }
 
     context 'when successful and not cached' do
@@ -51,6 +51,15 @@ RSpec.describe Mas::Cms::Connection do
       let(:status) { 301 }
       it 'raises a `HttpRedirect` instance for http 301 status' do
         expect { connection.get(path) }.to raise_exception Mas::Cms::HttpRedirect
+      end
+    end
+
+    context 'when response body is null' do
+      let(:response) { double(status: status, headers: {}, body: nil) }
+      before { allow(connection.raw_connection).to receive(:get).and_return(response) }
+
+      it 'raises an `Mas::Cms::Connection::ResourceNotFound error' do
+        expect { connection.get(path) }.to raise_error(Mas::Cms::Errors::ResourceNotFound)
       end
     end
 


### PR DESCRIPTION
[TP 8806](https://moneyadviceservice.tpondemand.com/entity/8806-mas-cms-client-does-not-handle)

Categories do not return `404` status when missing instead choosing to return a `200` status and a body of `null`

While this is valid JSON most parses have some trouble dealing with this so quirks mode must be enabled example:

```Ruby
irb(main):007:0> JSON.parse('null', quirks_mode:true)
=> nil
irb(main):008:0> JSON.parse('null')
JSON::ParserError: 784: unexpected token at 'null'
        from /Users/phil/.gem/ruby/2.3.3/gems/json-1.8.6/lib/json/common.rb:155:in `parse'
        from /Users/phil/.gem/ruby/2.3.3/gems/json-1.8.6/lib/json/common.rb:155:in `parse'
        from (irb):8
        from /Users/phil/.rubies/ruby-2.3.3/bin/irb:11:in `<main>'
```

This PR enables the quirks mode in the faraday middleware and raises the expected exception similar to if a 404 status had been detected.