### PR TITLE
[DEV APPROVED] 8812 Add Home Page Preview as page type

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The gems supports the following types:
   * News
   * Video
   * Home Page
+  * Home Page Preview
   * Footer
 
 The CMS API only support a GET request to pages at the moment
@@ -116,6 +117,9 @@ Mas::Cms::Video.find('budgeting-for-retirement')
 
 Mas::Cms::HomePage.find('the-money-advice-service')
 # GET /api/en/home_pages/the-money-advice-service.json
+
+Mas::Cms::HomePagePreview.find('the-money-advice-service')
+# GET /api/preview/en/home_pages/the-money-advice-service.json
 
 Mas::Cms::Footer.find('footer')
 # GET /api/en/footers/footer.json

--- a/lib/mas/cms.rb
+++ b/lib/mas/cms.rb
@@ -25,6 +25,7 @@ module Mas
     autoload :Entity, 'mas/cms/entity'
     autoload :Footer, 'mas/cms/entity/footer'
     autoload :HomePage, 'mas/cms/entity/home_page'
+    autoload :HomePagePreview, 'mas/cms/entity/home_page_preview'
     autoload :News, 'mas/cms/entity/news'
     autoload :NewsCollection, 'mas/cms/entity/news_collection'
     autoload :Other, 'mas/cms/entity/other'

--- a/lib/mas/cms/client/version.rb
+++ b/lib/mas/cms/client/version.rb
@@ -1,7 +1,7 @@
 module Mas
   module Cms
     module Client
-      VERSION = '1.5.1'.freeze
+      VERSION = '1.6.0'.freeze
     end
   end
 end

--- a/lib/mas/cms/entity/home_page_preview.rb
+++ b/lib/mas/cms/entity/home_page_preview.rb
@@ -1,0 +1,14 @@
+module Mas::Cms
+  class HomePagePreview < HomePage
+    def self.path(slug:, locale:)
+      [
+        api_prefix,
+        'preview',
+        locale,
+        slug
+      ].compact
+        .join('/')
+        .downcase + '.json'
+    end
+  end
+end

--- a/spec/mas/cms/entity/home_page_preview_spec.rb
+++ b/spec/mas/cms/entity/home_page_preview_spec.rb
@@ -1,0 +1,18 @@
+module Mas::Cms
+  RSpec.describe HomePagePreview, type: :model do
+    it_has_behavior 'a cms page entity'
+    subject { described_class.new(double, attributes) }
+
+    it { expect(described_class.superclass).to be(Mas::Cms::HomePage) }
+
+    describe '.path' do
+      subject(:path) do
+        described_class.path(slug: 'home', locale: 'en')
+      end
+
+      it 'returns home page preview path' do
+        expect(path).to eq('/api/preview/en/home.json')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is for [TP ticket 8812](https://moneyadviceservice.tpondemand.com/entity/8812-add-home-page-preview-page-type)

### What?
The Home Page Preview page type does not currently exist in mas-cms-client. This PR adds it.

### Why?
We want to replace the legacy implementation of retrieving the Home Page in Frontend with the mas-cms-client gem, as described in [TP 8666](https://moneyadviceservice.tpondemand.com/entity/8666-use-mas-cms-client-gem-on).
In order to achieve this we also need to be able to replace the implementation for Home Page Preview.


