### PR TITLE
[DEV APPROVED] 8830 Add VideoPreview and fix issue with missing Video attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The gems supports the following types:
   * Category
   * News
   * Video
+  * Video Preview
   * Home Page
   * Home Page Preview
   * Footer
@@ -114,6 +115,9 @@ Mas::Cms::News.find('new-rules-could-make-it-harder-to-get-a-payday-loan')
 
 Mas::Cms::Video.find('budgeting-for-retirement')
 # GET /api/en/videos/budgeting-for-retirement.json
+
+Mas::Cms::VideoPreview.find('budgeting-for-retirement')
+# GET /api/preview/en/videos/budgeting-for-retirement.json
 
 Mas::Cms::HomePage.find('the-money-advice-service')
 # GET /api/en/home_pages/the-money-advice-service.json

--- a/lib/mas/cms.rb
+++ b/lib/mas/cms.rb
@@ -33,6 +33,7 @@ module Mas
     autoload :StaticPage, 'mas/cms/entity/static_page'
     autoload :UniversalCredit, 'mas/cms/entity/universal_credit'
     autoload :Video, 'mas/cms/entity/video'
+    autoload :VideoPreview, 'mas/cms/entity/video_preview'
     autoload :WebChat, 'mas/cms/entity/web_chat'
 
     module Feedback

--- a/lib/mas/cms.rb
+++ b/lib/mas/cms.rb
@@ -1,4 +1,5 @@
 require 'mas/cms/connection'
+require 'mas/cms/preview'
 require 'mas/cms/resource'
 require 'mas/cms/client/version'
 require 'active_model'

--- a/lib/mas/cms/client/version.rb
+++ b/lib/mas/cms/client/version.rb
@@ -1,7 +1,7 @@
 module Mas
   module Cms
     module Client
-      VERSION = '1.6.1'.freeze
+      VERSION = '1.7.0'.freeze
     end
   end
 end

--- a/lib/mas/cms/entity/article_preview.rb
+++ b/lib/mas/cms/entity/article_preview.rb
@@ -1,14 +1,5 @@
 module Mas::Cms
   class ArticlePreview < Article
-    def self.path(slug:, locale:)
-      [
-        api_prefix,
-        'preview',
-        locale,
-        slug
-      ].compact
-        .join('/')
-        .downcase + '.json'
-    end
+    include Mas::Cms::Preview
   end
 end

--- a/lib/mas/cms/entity/home_page_preview.rb
+++ b/lib/mas/cms/entity/home_page_preview.rb
@@ -1,14 +1,5 @@
 module Mas::Cms
   class HomePagePreview < HomePage
-    def self.path(slug:, locale:)
-      [
-        api_prefix,
-        'preview',
-        locale,
-        slug
-      ].compact
-        .join('/')
-        .downcase + '.json'
-    end
+    include Mas::Cms::Preview
   end
 end

--- a/lib/mas/cms/entity/video.rb
+++ b/lib/mas/cms/entity/video.rb
@@ -1,5 +1,5 @@
 module Mas::Cms
-  class Video < Entity
+  class Video < Page
     include Mas::Cms::Resource
 
     attr_accessor :type, :title, :description, :body, :categories, :alternates

--- a/lib/mas/cms/entity/video_preview.rb
+++ b/lib/mas/cms/entity/video_preview.rb
@@ -1,0 +1,14 @@
+module Mas::Cms
+  class VideoPreview < Video
+    def self.path(slug:, locale:)
+      [
+        api_prefix,
+        'preview',
+        locale,
+        slug
+      ].compact
+        .join('/')
+        .downcase + '.json'
+    end
+  end
+end

--- a/lib/mas/cms/entity/video_preview.rb
+++ b/lib/mas/cms/entity/video_preview.rb
@@ -1,14 +1,5 @@
 module Mas::Cms
   class VideoPreview < Video
-    def self.path(slug:, locale:)
-      [
-        api_prefix,
-        'preview',
-        locale,
-        slug
-      ].compact
-        .join('/')
-        .downcase + '.json'
-    end
+    include Mas::Cms::Preview
   end
 end

--- a/lib/mas/cms/preview.rb
+++ b/lib/mas/cms/preview.rb
@@ -1,0 +1,20 @@
+module Mas::Cms
+  module Preview
+    def self.included(klass)
+      klass.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def path(slug:, locale:)
+        [
+          api_prefix,
+          'preview',
+          locale,
+          slug
+        ].compact
+          .join('/')
+          .downcase + '.json'
+      end
+    end
+  end
+end

--- a/spec/mas/cms/entity/article_preview_spec.rb
+++ b/spec/mas/cms/entity/article_preview_spec.rb
@@ -1,18 +1,10 @@
 module Mas::Cms
   RSpec.describe ArticlePreview, type: :model do
     it_has_behavior 'a cms page entity'
+    it_has_behavior 'a cms preview page'
+
     subject { described_class.new(double, attributes) }
 
     it { expect(described_class.superclass).to be(Mas::Cms::Article) }
-
-    describe '.path' do
-      subject(:path) do
-        described_class.path(slug: 'foo', locale: 'en')
-      end
-
-      it 'returns article preview path' do
-        expect(path).to eq('/api/preview/en/foo.json')
-      end
-    end
   end
 end

--- a/spec/mas/cms/entity/home_page_preview_spec.rb
+++ b/spec/mas/cms/entity/home_page_preview_spec.rb
@@ -1,18 +1,10 @@
 module Mas::Cms
   RSpec.describe HomePagePreview, type: :model do
     it_has_behavior 'a cms page entity'
+    it_has_behavior 'a cms preview page'
+
     subject { described_class.new(double, attributes) }
 
     it { expect(described_class.superclass).to be(Mas::Cms::HomePage) }
-
-    describe '.path' do
-      subject(:path) do
-        described_class.path(slug: 'home', locale: 'en')
-      end
-
-      it 'returns home page preview path' do
-        expect(path).to eq('/api/preview/en/home.json')
-      end
-    end
   end
 end

--- a/spec/mas/cms/entity/video_preview_spec.rb
+++ b/spec/mas/cms/entity/video_preview_spec.rb
@@ -1,0 +1,18 @@
+module Mas::Cms
+  RSpec.describe VideoPreview, type: :model do
+    it_has_behavior 'a cms page entity'
+    subject { described_class.new(double, attributes) }
+
+    it { expect(described_class.superclass).to be(Mas::Cms::Video) }
+
+    describe '.path' do
+      subject(:path) do
+        described_class.path(slug: 'fake-video', locale: 'en')
+      end
+
+      it 'returns video preview path' do
+        expect(path).to eq('/api/preview/en/fake-video.json')
+      end
+    end
+  end
+end

--- a/spec/mas/cms/entity/video_preview_spec.rb
+++ b/spec/mas/cms/entity/video_preview_spec.rb
@@ -1,18 +1,10 @@
 module Mas::Cms
   RSpec.describe VideoPreview, type: :model do
     it_has_behavior 'a cms page entity'
+    it_has_behavior 'a cms preview page'
+
     subject { described_class.new(double, attributes) }
 
     it { expect(described_class.superclass).to be(Mas::Cms::Video) }
-
-    describe '.path' do
-      subject(:path) do
-        described_class.path(slug: 'fake-video', locale: 'en')
-      end
-
-      it 'returns video preview path' do
-        expect(path).to eq('/api/preview/en/fake-video.json')
-      end
-    end
   end
 end

--- a/spec/mas/cms/entity/video_spec.rb
+++ b/spec/mas/cms/entity/video_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Mas::Cms::Video, type: :model do
-  it_has_behavior 'a cms resource entity'
+  it_has_behavior 'a cms page entity'
 
   let(:params) do
     {
@@ -7,7 +7,7 @@ RSpec.describe Mas::Cms::Video, type: :model do
       title: 'awesome-title',
       description: 'awesome-description',
       body: 'awesome-body',
-      categories: %i(foo bar),
+      categories: %i[foo bar],
       alternates: [:cy]
     }
   end
@@ -18,7 +18,7 @@ RSpec.describe Mas::Cms::Video, type: :model do
 
   describe 'attributes' do
     it 'are set' do
-      %i(type title description body categories alternates).each do |attr|
+      %i[type title description body categories alternates].each do |attr|
         expect(subject.public_send(attr)).to eql(params[attr])
       end
     end

--- a/spec/support/shared_examples/preview.rb
+++ b/spec/support/shared_examples/preview.rb
@@ -1,0 +1,15 @@
+RSpec.shared_examples_for 'a cms preview page' do
+  it 'behaves as a preview' do
+    expect(described_class.included_modules).to include(Mas::Cms::Preview)
+  end
+
+  describe '.path' do
+    subject(:path) do
+      described_class.path(slug: 'some-page-id', locale: 'en')
+    end
+
+    it 'returns preview path' do
+      expect(path).to eq('/api/preview/en/some-page-id.json')
+    end
+  end
+end


### PR DESCRIPTION
**Target Process ticket**

[TP 8830](https://moneyadviceservice.tpondemand.com/entity/8830-changes-to-gem-to-enable-use)

**Summary**
In order to support [TP 8669](https://moneyadviceservice.tpondemand.com/entity/8669-use-mas-cms-client-gem-on) a `VideoPreview` page type is needed, this PR adds it.

Additional notes:
* Whilst replacing the legacy code with the call to `Mas::Cms::Video`, it was discovered that attributes were not being set correctly on the returned `Video`. Changing that class to inherit from `Page` means that it now uses the `AttributeBuilder`, which resolves the issue.
* I've extracted the duplicate code from `ArticlePreview`, `HomePagePreview` and `VideoPreview` into a `Preview` module. Happy to revert this if it's adding unnecessary complication.
