### PR TITLE
[DEV APPROVED] 8395 Added Webchat entity

### DIFF
--- a/lib/mas/cms/client/version.rb
+++ b/lib/mas/cms/client/version.rb
@@ -1,7 +1,7 @@
 module Mas
   module Cms
     module Client
-      VERSION = '1.7.0'.freeze
+      VERSION = '1.7.1'.freeze
     end
   end
 end

--- a/lib/mas/cms/entity/footer.rb
+++ b/lib/mas/cms/entity/footer.rb
@@ -7,6 +7,9 @@ module Mas::Cms
       @contact ||= Mas::Cms::Contact.new(contact_options)
     end
 
+    def web_chat
+      @web_chat ||= Mas::Cms::WebChat.new(web_chat_options)
+    end
     # BaseContentReader attempts to 'build categories', our entity
     # doesn't need them so lets stub out the behaviour to keep it happy.
     def categories
@@ -31,6 +34,16 @@ module Mas::Cms
         additional_two: find_block_value('raw_contact_additional_two'),
         additional_three: find_block_value('raw_contact_additional_three'),
         small_print: find_block_value('raw_contact_small_print')
+      }
+    end
+
+    def web_chat_options
+      {
+        heading: find_block_value('raw_web_chat_heading'),
+        additional_one: find_block_value('raw_web_chat_additional_one'),
+        additional_two: find_block_value('raw_web_chat_additional_two'),
+        additional_three: find_block_value('raw_web_chat_additional_three'),
+        small_print: find_block_value('raw_web_chat_small_print')
       }
     end
   end

--- a/lib/mas/cms/entity/web_chat.rb
+++ b/lib/mas/cms/entity/web_chat.rb
@@ -1,0 +1,7 @@
+module Mas::Cms
+  class WebChat
+    include ActiveModel::Model
+    attr_accessor :heading, :additional_one, :additional_two,
+                  :additional_three, :small_print
+  end
+end

--- a/spec/mas/cms/entity/footer_spec.rb
+++ b/spec/mas/cms/entity/footer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Mas::Cms::Footer, type: :model do
       expect(subject.contact).to be_a(Mas::Cms::Contact)
     end
 
-    it "doesn't make multiple instances of contact if called multiple times" do
+    it 'doesn\'t make multiple instances of contact if called multiple times' do
       allow(Mas::Cms::Contact).to receive(:new).and_call_original
       3.times { subject.contact }
       expect(Mas::Cms::Contact).to have_received(:new).once
@@ -39,5 +39,23 @@ RSpec.describe Mas::Cms::Footer, type: :model do
     it { expect(subject.contact.additional_one).to eq('Monday to Friday, 8am to 8pm') }
     it { expect(subject.contact.additional_two).to eq('Saturday, 9am to 1pm') }
     it { expect(subject.contact.additional_three).to eq('Sunday and Bank Holidays, closed') }
+  end
+
+  describe '#web_chat' do
+    it 'returns a WebChat object' do
+      expect(subject.web_chat).to be_a(Mas::Cms::WebChat)
+    end
+
+    it 'doesn\'t make multiple instances of contact if called multiple times' do
+      allow(Mas::Cms::WebChat).to receive(:new).and_call_original
+      3.times { subject.web_chat }
+      expect(Mas::Cms::WebChat).to have_received(:new).once
+    end
+
+    it { expect(subject.web_chat.heading).to eq('Web Chat') }
+    it { expect(subject.web_chat.additional_one).to eq('Monday to Friday, 8am to 8pm') }
+    it { expect(subject.web_chat.additional_two).to eq('Saturday, 9am to 1pm') }
+    it { expect(subject.web_chat.additional_three).to eq('Sunday and Bank Holidays, closed') }
+    it { expect(subject.web_chat.small_print).to eq('some small print') }
   end
 end

--- a/spec/mas/cms/entity/web_chat_spec.rb
+++ b/spec/mas/cms/entity/web_chat_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Mas::Cms::WebChat, type: :model do
+  let(:params) do
+    {
+      heading: 'Web Chat',
+      additional_one: 'Mon-Fri 8am-6pm',
+      additional_two: 'Sat 10am-4pm',
+      additional_three: 'closed Sun',
+      small_print: 'small print'
+    }
+  end
+
+  subject { described_class.new(params) }
+
+  describe 'attributes' do
+    it { expect(subject.heading).to eq('Web Chat') }
+    it { expect(subject.additional_one).to eq('Mon-Fri 8am-6pm') }
+    it { expect(subject.additional_two).to eq('Sat 10am-4pm') }
+    it { expect(subject.additional_three).to eq('closed Sun') }
+    it { expect(subject.small_print).to eq('small print') }
+  end
+end


### PR DESCRIPTION
[TP #8395](https://moneyadviceservice.tpondemand.com/entity/8935-add-web-chat-to-footer-entity)

The footer entity does not currently include the web chat entity that is required by frontend.

This PR adds the `WebChat` entity and the accompanying method in `Footer`