### PR TITLE
[DEV APPROVED] Add compatibility to Rails 5

### DIFF
--- a/mas-cms-client.gemspec
+++ b/mas-cms-client.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activemodel', '~> 4.2'
-  spec.add_runtime_dependency 'activesupport', '~> 4.2'
+  spec.add_runtime_dependency 'activemodel', '>= 4.2'
+  spec.add_runtime_dependency 'activesupport', '>= 4.2'
   spec.add_runtime_dependency 'faraday', '~> 0.9.2'
   spec.add_runtime_dependency 'faraday-conductivity', '~> 0.3.1'
   spec.add_runtime_dependency 'faraday_middleware', '~> 0.10.0'


### PR DESCRIPTION
## Context

Since I start to add mas-cms-client gem to the [Fincap]() the bundler complain:

```
Bundler could not find compatible versions for gem "activemodel":
  In snapshot (Gemfile.lock):
    activemodel (= 5.0.6)

  In Gemfile:
    mas-cms-client was resolved to 1.1.0, which depends on
      activemodel (>= 4.2.7, ~> 4.2)

    rails (~> 5.0.6) was resolved to 5.0.6, which depends on
      activemodel (= 5.0.6)

    web-console (>= 3.3.0) was resolved to 3.5.1, which depends on
      activemodel (>= 5.0)
```

The reason is the gem *officially* does not support Rails 5. Changing the gemspec allow us to use the gem on Rails 5 applications.