### PR TITLE
[DEV APPROVED] 9015 - Add Document.all request

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The gems supports the following types:
   * Home Page
   * Home Page Preview
   * Footer
+  * Document
 
 The CMS API only support a GET request to pages at the moment
 and you can **find any page** by the following:
@@ -127,6 +128,9 @@ Mas::Cms::HomePagePreview.find('the-money-advice-service')
 
 Mas::Cms::Footer.find('footer')
 # GET /api/en/footers/footer.json
+
+Mas::Cms::Document.all
+# GET /api/en/documents.json
 ```
 
 ### Switching Locale

--- a/lib/mas/cms.rb
+++ b/lib/mas/cms.rb
@@ -23,6 +23,7 @@ module Mas
     autoload :Corporate, 'mas/cms/entity/corporate'
     autoload :CorporateCategory, 'mas/cms/entity/corporate_category'
     autoload :Customer, 'mas/cms/entity/customer'
+    autoload :Document, 'mas/cms/entity/document'
     autoload :Entity, 'mas/cms/entity'
     autoload :Footer, 'mas/cms/entity/footer'
     autoload :HomePage, 'mas/cms/entity/home_page'

--- a/lib/mas/cms/entity/document.rb
+++ b/lib/mas/cms/entity/document.rb
@@ -1,0 +1,21 @@
+module Mas
+  module Cms
+    class Document < Mas::Cms::Page
+      attr_accessor :label,
+                    :slug,
+                    :full_path,
+                    :meta_description,
+                    :meta_title,
+                    :category_names,
+                    :layout_identifier,
+                    :related_content,
+                    :blocks
+
+      ROOT_NAME = 'documents'.freeze
+
+      def self.root_name
+        ROOT_NAME
+      end
+    end
+  end
+end

--- a/lib/mas/cms/entity/footer.rb
+++ b/lib/mas/cms/entity/footer.rb
@@ -10,6 +10,7 @@ module Mas::Cms
     def web_chat
       @web_chat ||= Mas::Cms::WebChat.new(web_chat_options)
     end
+
     # BaseContentReader attempts to 'build categories', our entity
     # doesn't need them so lets stub out the behaviour to keep it happy.
     def categories

--- a/lib/mas/cms/resource.rb
+++ b/lib/mas/cms/resource.rb
@@ -34,6 +34,9 @@ module Mas
 
         def all(locale: 'en', cached: Mas::Cms::Client.config.cache_gets)
           response_body = http.get(path(slug: nil, locale: locale), cached: cached).body
+
+          response_body = response_body[root_name] if root_name
+
           response_body.map do |entity_attrs|
             new(
               entity_attrs.delete(:id),
@@ -41,6 +44,8 @@ module Mas
             )
           end
         end
+
+        def root_name; end
 
         def create(attributes = {})
           body = http.post(

--- a/spec/mas/cms/entity/document_spec.rb
+++ b/spec/mas/cms/entity/document_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Mas::Cms::Document do
+  it_has_behavior 'a cms page entity'
+
+  describe '.root_name' do
+    it 'returns "documents"' do
+      expect(described_class.root_name).to eq('documents')
+    end
+  end
+end

--- a/spec/mas/cms/entity/video_spec.rb
+++ b/spec/mas/cms/entity/video_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Mas::Cms::Video, type: :model do
       title: 'awesome-title',
       description: 'awesome-description',
       body: 'awesome-body',
-      categories: %i[foo bar],
+      categories: %i(foo bar),
       alternates: [:cy]
     }
   end
@@ -18,7 +18,7 @@ RSpec.describe Mas::Cms::Video, type: :model do
 
   describe 'attributes' do
     it 'are set' do
-      %i[type title description body categories alternates].each do |attr|
+      %i(type title description body categories alternates).each do |attr|
         expect(subject.public_send(attr)).to eql(params[attr])
       end
     end

--- a/spec/mas/cms/resource_spec.rb
+++ b/spec/mas/cms/resource_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe Mas::Cms::Resource do
     BarFoo
   end
 
+  let(:entity_with_root_name) do
+    class EntityWithRootName < Mas::Cms::Entity
+      include Mas::Cms::Resource
+
+      def self.root_name
+        :entity_with_root_name
+      end
+    end
+  end
+
   let(:modularized_entity) do
     module ModularizedEntity
       module Foo
@@ -135,6 +145,27 @@ RSpec.describe Mas::Cms::Resource do
       { locale: 'en' }
     end
     let(:entities) { entity_class.all(args) }
+
+    context 'when API response has a root node' do
+      let(:entity_class) do
+        entity_with_root_name
+        EntityWithRootName
+      end
+
+      let(:data_attributes) do
+        {
+          entity_with_root_name: [
+            { id: 1 },
+            { id: 2 }
+          ]
+        }
+      end
+
+      it 'returns a fully instantiated entities instance' do
+        expect(entities[0].id).to eq(1)
+        expect(entities[1].id).to eq(2)
+      end
+    end
 
     context 'when API call successful' do
       it 'returns an array of entity' do


### PR DESCRIPTION
[TP-card](https://moneyadviceservice.tpondemand.com/entity/9015-add-documentall-to-mas-cms-client)
This is the client request to the CMS API work that was done on https://github.com/moneyadviceservice/cms/pull/403

## Context

The document resource on CMS uses root nodes on the response,
and this commit add the possibility for you to extend the resource
adding the 'root_node' method to your class.
Refer to lib/mas/cms/entity/document.rb for an example