### PR TITLE
[DEV APPROVED] Add rubocop check to test.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -9,4 +9,5 @@ export PATH=./bin:$PATH
 CI_PIPELINE_COUNTER=${GO_PIPELINE_LABEL-0}
 CI_EXECUTOR_NUMBER=${EXECUTOR_NUMBER-0}
 
+bundle exec rubocop .
 bundle exec rspec


### PR DESCRIPTION
*No TP cards*.

There was no rubocop check on this test.sh gem. Add one so it can run on our CI.