### PR TITLE
[DEV APPROVED] 9038 - Allow params in Resource.all requests

### DIFF
--- a/lib/mas/cms/client/version.rb
+++ b/lib/mas/cms/client/version.rb
@@ -1,7 +1,7 @@
 module Mas
   module Cms
     module Client
-      VERSION = '1.9.0'.freeze
+      VERSION = '1.10.0'.freeze
     end
   end
 end

--- a/lib/mas/cms/connection.rb
+++ b/lib/mas/cms/connection.rb
@@ -26,9 +26,9 @@ module Mas
       end
       # rubocop:enable Metrics/AbcSize
 
-      def get(path, cached: Mas::Cms::Client.config.cache_gets)
+      def get(path, cached: Mas::Cms::Client.config.cache_gets, params: nil)
         with_exception_support do
-          request = ->(_) { raw_connection.get(path) }
+          request = ->(_) { raw_connection.get(path, params) }
           response = fetch_from_cache_or_request(path, cached, &request)
           raise HttpRedirect.new(response) if HttpRedirect.redirect?(response)
           raise Errors::ResourceNotFound if response.body.nil?

--- a/lib/mas/cms/resource.rb
+++ b/lib/mas/cms/resource.rb
@@ -32,8 +32,12 @@ module Mas
           new(slug, attributes)
         end
 
-        def all(locale: 'en', cached: Mas::Cms::Client.config.cache_gets)
-          response_body = http.get(path(slug: nil, locale: locale), cached: cached).body
+        def all(locale: 'en', cached: Mas::Cms::Client.config.cache_gets, params: nil)
+          response_body = http.get(
+            path(slug: nil, locale: locale),
+            params: params,
+            cached: cached
+          ).body
 
           response_body = response_body[root_name] if root_name
 

--- a/spec/mas/cms/connection_spec.rb
+++ b/spec/mas/cms/connection_spec.rb
@@ -32,9 +32,21 @@ RSpec.describe Mas::Cms::Connection do
     let(:response) { double(status: status, headers: {}, body: {}) }
     let(:status)   { 200 }
 
+    context 'when sending params' do
+      let(:params) { { document_type: 'Insight' } }
+
+      it 'delegates to raw_connection with params' do
+        expect(connection.raw_connection).to receive(:get).with(
+          path,
+          params
+        ).and_return(response)
+        connection.get(path, params: params, cached: false)
+      end
+    end
+
     context 'when successful and not cached' do
       it 'delegates to raw_connection' do
-        expect(connection.raw_connection).to receive(:get).with(path).and_return(response)
+        expect(connection.raw_connection).to receive(:get).with(path, nil).and_return(response)
         connection.get(path, cached: false)
       end
     end
@@ -67,9 +79,10 @@ RSpec.describe Mas::Cms::Connection do
       before do
         allow(connection.raw_connection)
           .to receive(:get)
-          .with(path)
+          .with(path, nil)
           .and_raise(Faraday::Error::ResourceNotFound, 'foo')
       end
+
       it 'raises an `Mas::Cms::Connection::ResourceNotFound error' do
         expect { connection.get(path) }.to raise_error(Mas::Cms::Errors::ResourceNotFound)
       end
@@ -79,7 +92,7 @@ RSpec.describe Mas::Cms::Connection do
       before do
         allow(connection.raw_connection)
           .to receive(:get)
-          .with(path)
+          .with(path, nil)
           .and_raise(Faraday::Error::ConnectionFailed, 'foo')
       end
       it 'raises an `Mas::Cms::Connection::ConnectionFailed error' do
@@ -91,9 +104,10 @@ RSpec.describe Mas::Cms::Connection do
       before do
         allow(connection.raw_connection)
           .to receive(:get)
-          .with(path)
+          .with(path, nil)
           .and_raise(Faraday::Error::ClientError.new('foo', status: 500))
       end
+
       it 'raises an `Mas::Cms::Connection::ClientError error' do
         expect { connection.get(path) }.to raise_error(Mas::Cms::Errors::ClientError)
       end

--- a/spec/mas/cms/resource_spec.rb
+++ b/spec/mas/cms/resource_spec.rb
@@ -179,7 +179,11 @@ RSpec.describe Mas::Cms::Resource do
 
       it 'query correct cms resource' do
         entities
-        expect(conn).to have_received(:get).with('/api/en/poker_card.json', cached: nil)
+        expect(conn).to have_received(:get).with(
+          '/api/en/poker_card.json',
+          params: nil,
+          cached: nil
+        )
       end
 
       context 'locale params defaults to `en`' do
@@ -187,6 +191,19 @@ RSpec.describe Mas::Cms::Resource do
 
         it 'returns an array of entity' do
           expect(entities).to all(be_an(A))
+        end
+      end
+
+      context 'send params' do
+        let(:args) { { params: { document_type: 'Insight' } } }
+
+        it 'pass the params to the get request' do
+          entities
+          expect(conn).to have_received(:get).with(
+            '/api/en/poker_card.json',
+            params: args[:params],
+            cached: nil
+          )
         end
       end
     end


### PR DESCRIPTION
[TP task](https://moneyadviceservice.tpondemand.com/entity/9038-mas-cms-client-should-send-the) from [TP card](https://moneyadviceservice.tpondemand.com/entity/8773-evhub-resultssearch-page-insights)

## Context 

Before this implementation, we were requesting all documents to the CMS.
 
This would be a problem when new page types like articles enter on CMS because then the evidence hub could contain undesired page types on evidence summaries.
 
So this task cover to add the request all "Insight documents" to the CMS on the mas-cms-client gem.

So now the gem has support to pass parameters when you're requesting a collection like `/api/en/documents.json` then is possible to pass params on the request like
`/api/en/documents.json?document_type=Insight`
