### PR TITLE
[DEV APPROVED] Add post-step to clear workspace after jenkins job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,4 +18,9 @@ pipeline {
             }
         }
     }
+    post {
+        always {
+            cleanWs()
+        }
+    }
 }


### PR DESCRIPTION
This change add a post pipeline step to clear the Jenkins workspace. This prevents issues occurring with stale code in subsequent jobs.