### PR TITLE
Add extra blocks attribute to article pages

### DIFF
--- a/lib/mas/cms.rb
+++ b/lib/mas/cms.rb
@@ -16,6 +16,7 @@ module Mas
     autoload :Article, 'mas/cms/entity/article'
     autoload :ArticlePreview, 'mas/cms/entity/article_preview'
     autoload :ArticleLink, 'mas/cms/entity/article_link'
+    autoload :Block, 'mas/cms/entity/block'
     autoload :Category, 'mas/cms/entity/category'
     autoload :Clump, 'mas/cms/entity/clump'
     autoload :ClumpLink, 'mas/cms/entity/clump_link'

--- a/lib/mas/cms/client/version.rb
+++ b/lib/mas/cms/client/version.rb
@@ -1,7 +1,7 @@
 module Mas
   module Cms
     module Client
-      VERSION = '1.10.0'.freeze
+      VERSION = '1.11.0'.freeze
     end
   end
 end

--- a/lib/mas/cms/entity/article.rb
+++ b/lib/mas/cms/entity/article.rb
@@ -2,7 +2,16 @@ module Mas::Cms
   class Article < Page
     Alternate = Struct.new(:title, :url, :hreflang)
 
-    attr_accessor :type, :slug, :identifier, :title, :description, :body, :categories, :related_content, :supports_amp
+    attr_accessor :type,
+                  :slug,
+                  :identifier,
+                  :title,
+                  :description,
+                  :body,
+                  :categories,
+                  :related_content,
+                  :supports_amp,
+                  :non_content_blocks
     attr_reader :alternates
 
     validates_presence_of :title, :body

--- a/lib/mas/cms/entity/block.rb
+++ b/lib/mas/cms/entity/block.rb
@@ -1,0 +1,11 @@
+module Mas::Cms
+  class Block
+    include ActiveModel::Model
+
+    attr_accessor :identifier, :content
+
+    def ==(other)
+      identifier == other.identifier && content == other.content
+    end
+  end
+end

--- a/lib/mas/cms/repository/cms/attribute_builder.rb
+++ b/lib/mas/cms/repository/cms/attribute_builder.rb
@@ -19,6 +19,7 @@ module Mas::Cms::Repository
 
         assign_title_from_label(attributes)
         assign_body_from_content_block(attributes)
+        assign_blocks_excluding_content(attributes)
 
         translate_attributes_from_raw_blocks(attributes)
         group_nested_attributes(attributes)
@@ -38,6 +39,19 @@ module Mas::Cms::Repository
 
       def assign_body_from_content_block(attributes)
         attributes['body'] = BlockComposer.new(attributes['blocks']).to_html
+      end
+
+      def assign_blocks_excluding_content(attributes)
+        blocks_without_content = attributes['blocks'].select do |block|
+          block['identifier'] != 'content'
+        end
+
+        attributes['non_content_blocks'] = Array(blocks_without_content).map do |block|
+          ::Mas::Cms::Block.new(
+            identifier: block['identifier'],
+            content: block['content']
+          )
+        end
       end
 
       def assign_description(attributes)

--- a/spec/fixtures/cms/article-components.json
+++ b/spec/fixtures/cms/article-components.json
@@ -1,0 +1,75 @@
+{
+   "label":"UK Strategy",
+   "slug":"uk-strategy",
+   "full_path":"/en/articles/uk-strategy",
+   "meta_description":"",
+   "meta_title":"UK Strategy",
+   "category_names":[
+   ],
+   "layout_identifier":"article",
+   "related_content":{
+      "latest_blog_post_links":[
+         {
+            "title":"Is your bank closing? Here is what you can do",
+            "path":"https://www.moneyadviceservice.org.uk/blog/is-your-bank-closing-here-s-what-you-can-do"
+         },
+         {
+            "title":"Registering to vote and four other ways to help your credit rating",
+            "path":"https://www.moneyadviceservice.org.uk/blog/registering-to-vote-and-four-other-ways-to-help-your-credit-rating"
+         },
+         {
+            "title":"Four ways to start and keep saving",
+            "path":"https://www.moneyadviceservice.org.uk/blog/four-ways-to-start-and-keep-saving"
+         }
+      ],
+      "popular_links":[
+
+      ],
+      "related_links":[
+
+      ],
+      "previous_link":{
+
+      },
+      "next_link":{
+
+      }
+   },
+   "published_at":"2018-04-18T12:51:57.000Z",
+   "supports_amp":true,
+   "blocks":[
+      {
+         "identifier":"content",
+         "content":"some content",
+         "created_at":"2018-04-18T10:11:47.000Z",
+         "updated_at":"2018-04-18T10:27:23.000Z"
+      },
+      {
+         "identifier":"component_hero_image",
+         "content":"<p>/hero-sample.jpg</p>",
+         "created_at":"2018-04-18T12:48:03.000Z",
+         "updated_at":"2018-04-18T12:48:03.000Z"
+      },
+      {
+         "identifier":"component_cta_links",
+         "content":"cta links content",
+         "created_at":"2018-04-18T12:48:03.000Z",
+         "updated_at":"2018-04-18T12:51:57.000Z"
+      },
+      {
+         "identifier":"component_download",
+         "content":"something to be downloaded",
+         "created_at":"2018-04-18T12:48:03.000Z",
+         "updated_at":"2018-04-18T12:48:03.000Z"
+      },
+      {
+         "identifier":"component_feedback",
+         "content":"<p>email@moneyadviceservice.org.uk</p>",
+         "created_at":"2018-04-18T12:48:03.000Z",
+         "updated_at":"2018-04-18T12:48:03.000Z"
+      }
+   ],
+   "translations":[
+   ]
+}
+

--- a/spec/mas/cms/attribute_builder_spec.rb
+++ b/spec/mas/cms/attribute_builder_spec.rb
@@ -82,6 +82,33 @@ module Mas::Cms::Repository::CMS
         end
       end
 
+      context 'when parsing another blocks than content' do
+        let(:body) { File.read('spec/fixtures/cms/article-components.json') }
+
+        it 'returns blocks excluding content' do
+          expect(subject['non_content_blocks']).to match_array(
+            [
+              Mas::Cms::Block.new(
+                identifier: 'component_hero_image',
+                content: '<p>/hero-sample.jpg</p>'
+              ),
+              Mas::Cms::Block.new(
+                identifier: 'component_cta_links',
+                content: 'cta links content'
+              ),
+              Mas::Cms::Block.new(
+                identifier: 'component_download',
+                content: 'something to be downloaded'
+              ),
+              Mas::Cms::Block.new(
+                identifier: 'component_feedback',
+                content: '<p>email@moneyadviceservice.org.uk</p>'
+              )
+            ]
+          )
+        end
+      end
+
       context 'home page' do
         let(:body) { File.read('spec/fixtures/cms/modifiable-home-page.json') }
 

--- a/spec/mas/cms/entity/article_spec.rb
+++ b/spec/mas/cms/entity/article_spec.rb
@@ -18,16 +18,25 @@ module Mas::Cms
         ]
       }
     end
+    let(:non_content_blocks) { double }
+
     let(:attributes) do
       {
         title:       double,
         description: double,
         slug:        double,
         body:        double,
+        non_content_blocks: non_content_blocks,
         alternates:  [{ title: double, url: double, hreflang: double }],
         categories:  categories,
         related_content: related_content
       }
+    end
+
+    describe '#non_content_blocks' do
+      it 'returns extra blocks from attributes' do
+        expect(subject.non_content_blocks).to be(non_content_blocks)
+      end
     end
 
     describe '#previous_link' do


### PR DESCRIPTION
[]()

## Context

The Mas::Cms::Article entity does not have a way to access other blocks from response.

The current implementation ignores the other blocks that are not content.

So this PR address this issue by making sure that other blocks which are NOT content
can be accessed from article entity via #extra_blocks accessor.

```
[1] pry(main)> article = Mas::Cms::Article.find('some-article')
[2] pry(main)> article.non_content_blocks
=> [#<Mas::Cms::Block:0x007fded37dc378 @content="<p>/hero-sample.jpg</p>\n", @identifier="component_hero_image">,
 #<Mas::Cms::Block:0x007fded37dc080
  @content=
   "<p><a href=\"/financial+capability+strategy.pdf\">UK Strategy</a>\n<a href=\"/detailed-strategy.pdf\">UK Detailed Strategy</a>\n<a href=\"/key-statistics.pdf\">Key statistics on Financial Capability</a>\n<a href=\"/fincap+progress+report+2017.pdf\">Financial Capability Progress Report 2017</a></p>\n",
  @identifier="component_cta_links">,
 #<Mas::Cms::Block:0x007fded37d7df0 @content="<p><a href=\"link\">Text</a></p>\n", @identifier="component_download">,
 #<Mas::Cms::Block:0x007fded37d7c38 @content="<p>email@moneyadviceservice.org.uk</p>\n", @identifier="component_feedback">
```