### PR TITLE
Fix client error exception when exception does not have a response

### DIFF
--- a/lib/mas/cms/connection.rb
+++ b/lib/mas/cms/connection.rb
@@ -67,7 +67,8 @@ module Mas
       rescue Faraday::Error::ConnectionFailed
         raise Errors::ConnectionFailed
       rescue Faraday::Error::ClientError => error
-        case error.response[:status]
+        response_status = error.response[:status] if error.response
+        case response_status
         when 422
           raise Errors::UnprocessableEntity
         else

--- a/spec/mas/cms/connection_spec.rb
+++ b/spec/mas/cms/connection_spec.rb
@@ -136,6 +136,25 @@ RSpec.describe Mas::Cms::Connection do
       end
     end
 
+    context 'when ssl error' do
+      let(:faraday_exception) do
+        Faraday::SSLError.new('SSL_connect returned=1 errno=0')
+      end
+
+      before do
+        allow(connection.raw_connection)
+          .to receive(:post)
+          .with(params)
+          .and_raise(faraday_exception)
+      end
+
+      it 'raises an `Mas::Cms::Connection::ClientError error' do
+        expect { connection.post(params) }.to raise_error(
+          Mas::Cms::Errors::ClientError
+        )
+      end
+    end
+
     context 'when client error' do
       before do
         allow(connection.raw_connection)
@@ -143,6 +162,7 @@ RSpec.describe Mas::Cms::Connection do
           .with(params)
           .and_raise(Faraday::Error::ClientError.new('foo', status: 500))
       end
+
       it 'raises an `Mas::Cms::Connection::ClientError error' do
         expect { connection.post(params) }.to raise_error(Mas::Cms::Errors::ClientError)
       end
@@ -155,6 +175,7 @@ RSpec.describe Mas::Cms::Connection do
           .with(params)
           .and_raise(Faraday::Error::ClientError.new('foo', status: 422))
       end
+
       it 'raises an `Mas::Cms::Connection::UnprocessableEntity error' do
         expect { connection.post(params) }.to raise_error(Mas::Cms::Errors::UnprocessableEntity)
       end


### PR DESCRIPTION
## Context

Every time that there is an error on the client that is requesting the CMS *which is not a problem on the CMS* an weird error is raised:

![image](https://user-images.githubusercontent.com/27509/40473858-4809824e-5f35-11e8-8efa-860e3892df06.png)

This error above happens because there are some cases which the exception does not have a response. Like SSL errors, timeouts, so checking if there is a response makes the exception go through and raise the Mas::Cms::Errors::ClientError passing the right exception and the right message.

<img width="908" alt="screen shot 2018-05-24 at 09 32 33" src="https://user-images.githubusercontent.com/27509/40473907-76a775c0-5f35-11e8-8d90-2a59f2f4e86b.png">


