### PR TITLE
Bump version to 1.12.1

### DIFF
--- a/lib/mas/cms/client/version.rb
+++ b/lib/mas/cms/client/version.rb
@@ -1,7 +1,7 @@
 module Mas
   module Cms
     module Client
-      VERSION = '1.12.0'.freeze
+      VERSION = '1.12.1'.freeze
     end
   end
 end


### PR DESCRIPTION
This version fixes the handle of exceptions when the request raises an error without response. See #26  for more details.