### PR TITLE
Changes for fincap preview feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,21 +82,21 @@ Every page has its own type.
 
 The gems supports the following types:
 
+* Action Plan
 * Article
 * Article Preview
-* Action Plan
-* Corporate
 * Category
+* Corporate
+* Document
+* Evidence Summary Preview
+* Footer
+* Home Page
+* Home Page Preview
 * News
 * Video
 * Video Preview
-* Home Page
-* Home Page Preview
-* Footer
-* Document
 
-The CMS API supports a GET request to pages.
-
+The CMS API only supports GET requests to pages.
 Some examples of how to retrieve data from the CMS are given below.
 
 **find** any page:
@@ -117,14 +117,14 @@ Mas::Cms::Corporate.find('media-comment--money-mental-health-missing-link-report
 Mas::Cms::Category.find('pensions-and-retirement')
 # GET /api/en/categories/pensions-and-retirement.json
 
+Mas::Cms::EvidenceSummaryPreview.find('changing-behaviour-around-online-transactions')
+# GET /api/preview/en/changing-behaviour-around-online-transactions.json
+
+Mas::Cms::Footer.find('footer')
+# GET /api/en/footers/footer.json
+
 Mas::Cms::News.find('new-rules-could-make-it-harder-to-get-a-payday-loan')
 # GET /api/en/news/new-rules-could-make-it-harder-to-get-a-payday-loan.json
-
-Mas::Cms::Video.find('budgeting-for-retirement')
-# GET /api/en/videos/budgeting-for-retirement.json
-
-Mas::Cms::VideoPreview.find('budgeting-for-retirement')
-# GET /api/preview/en/videos/budgeting-for-retirement.json
 
 Mas::Cms::HomePage.find('the-money-advice-service')
 # GET /api/en/home_pages/the-money-advice-service.json
@@ -132,8 +132,11 @@ Mas::Cms::HomePage.find('the-money-advice-service')
 Mas::Cms::HomePagePreview.find('the-money-advice-service')
 # GET /api/preview/en/home_pages/the-money-advice-service.json
 
-Mas::Cms::Footer.find('footer')
-# GET /api/en/footers/footer.json
+Mas::Cms::Video.find('budgeting-for-retirement')
+# GET /api/en/videos/budgeting-for-retirement.json
+
+Mas::Cms::VideoPreview.find('budgeting-for-retirement')
+# GET /api/preview/en/videos/budgeting-for-retirement.json
 ```
 
 **all** documents or articles with:

--- a/lib/mas/cms.rb
+++ b/lib/mas/cms.rb
@@ -27,6 +27,7 @@ module Mas
     autoload :Customer, 'mas/cms/entity/customer'
     autoload :Document, 'mas/cms/entity/document'
     autoload :Entity, 'mas/cms/entity'
+    autoload :EvidenceSummaryPreview, 'mas/cms/entity/evidence_summary_preview'
     autoload :Footer, 'mas/cms/entity/footer'
     autoload :HomePage, 'mas/cms/entity/home_page'
     autoload :HomePagePreview, 'mas/cms/entity/home_page_preview'

--- a/lib/mas/cms/client/version.rb
+++ b/lib/mas/cms/client/version.rb
@@ -1,7 +1,7 @@
 module Mas
   module Cms
     module Client
-      VERSION = '1.13.1'.freeze
+      VERSION = '1.14.0'.freeze
     end
   end
 end

--- a/lib/mas/cms/entity/article.rb
+++ b/lib/mas/cms/entity/article.rb
@@ -17,11 +17,11 @@ module Mas::Cms
 
     ROOT_NAME = 'documents'.freeze
 
+    validates_presence_of :title, :body
+
     def self.root_name
       ROOT_NAME
     end
-
-    validates_presence_of :title, :body
 
     def alternates=(alternates)
       @alternates = alternates.map do |alternate|

--- a/lib/mas/cms/entity/evidence_summary_preview.rb
+++ b/lib/mas/cms/entity/evidence_summary_preview.rb
@@ -1,0 +1,5 @@
+module Mas::Cms
+  class EvidenceSummaryPreview < Document
+    include Mas::Cms::Preview
+  end
+end

--- a/spec/mas/cms/entity/evidence_summary_preview_spec.rb
+++ b/spec/mas/cms/entity/evidence_summary_preview_spec.rb
@@ -1,0 +1,10 @@
+module Mas::Cms
+  RSpec.describe EvidenceSummaryPreview, type: :model do
+    it_has_behavior 'a cms page entity'
+    it_has_behavior 'a cms preview page'
+
+    subject { described_class.new(double, attributes) }
+
+    it { expect(described_class.superclass).to be(Mas::Cms::Document) }
+  end
+end


### PR DESCRIPTION
[TP 9186](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&searchPopup=userstory/9186)

### Context
Fincap website editors need to preview their changes/additions to Fincap Evidence Summaries (Insights, Evaluations and Reviews),  once a draft version has been entered into the cms, before the document is published.

### Technical
Since insights, evaluations and reviews all inherit from EvidenceSummary, we only need to add 1 new class, EvidenceSummaryPreview which makes use of the Preview class. This work is in conjunction with work being done on Fincap.

This work also includes some code changes in line with our rubocop standards.