### PR TITLE
Add full_path attribute to Article

### DIFF
--- a/lib/mas/cms/client/version.rb
+++ b/lib/mas/cms/client/version.rb
@@ -1,7 +1,7 @@
 module Mas
   module Cms
     module Client
-      VERSION = '1.13.0'.freeze
+      VERSION = '1.13.1'.freeze
     end
   end
 end

--- a/lib/mas/cms/entity/article.rb
+++ b/lib/mas/cms/entity/article.rb
@@ -11,14 +11,15 @@ module Mas::Cms
                   :categories,
                   :related_content,
                   :supports_amp,
-                  :non_content_blocks
+                  :non_content_blocks,
+                  :full_path
     attr_reader :alternates
 
     ROOT_NAME = 'documents'.freeze
 
-      def self.root_name
-        ROOT_NAME
-      end
+    def self.root_name
+      ROOT_NAME
+    end
 
     validates_presence_of :title, :body
 

--- a/lib/mas/cms/repository/cms/attribute_builder.rb
+++ b/lib/mas/cms/repository/cms/attribute_builder.rb
@@ -42,8 +42,8 @@ module Mas::Cms::Repository
       end
 
       def assign_blocks_excluding_content(attributes)
-        blocks_without_content = attributes['blocks'].select do |block|
-          block['identifier'] != 'content'
+        blocks_without_content = attributes['blocks'].reject do |block|
+          block['identifier'] == 'content'
         end
 
         attributes['non_content_blocks'] = Array(blocks_without_content).map do |block|

--- a/spec/factories/category.rb
+++ b/spec/factories/category.rb
@@ -13,7 +13,7 @@ FactoryGirl.define do
       type 'category'
 
       trait :content_items do
-        contents { %w(article_hash action_plan_hash).map(&method(:build)) }
+        contents { %w[article_hash action_plan_hash].map(&method(:build)) }
       end
 
       initialize_with do

--- a/spec/mas/cms/config_spec.rb
+++ b/spec/mas/cms/config_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Mas::Cms::Config do
     config.cache_gets   = cache_gets
   end
 
-  %i(timeout open_timeout host api_token retries cache cache_gets).each do |attr|
+  %i[timeout open_timeout host api_token retries cache cache_gets].each do |attr|
     it "responds to `#{attr}`" do
       expect(config.send(attr)).to eq send(attr)
     end

--- a/spec/mas/cms/entity/article_spec.rb
+++ b/spec/mas/cms/entity/article_spec.rb
@@ -27,6 +27,7 @@ module Mas::Cms
         slug:        double,
         body:        double,
         non_content_blocks: non_content_blocks,
+        full_path:   double,
         alternates:  [{ title: double, url: double, hreflang: double }],
         categories:  categories,
         related_content: related_content

--- a/spec/mas/cms/entity/home_page_spec.rb
+++ b/spec/mas/cms/entity/home_page_spec.rb
@@ -6,7 +6,7 @@ module Mas::Cms
     let(:attributes) { {} }
 
     it 'has correct attributes' do
-      %i(promo_banner_url promo_banner_url).each do |attr|
+      %i[promo_banner_url promo_banner_url].each do |attr|
         expect(subject).to respond_to(attr)
       end
     end

--- a/spec/mas/cms/entity/video_spec.rb
+++ b/spec/mas/cms/entity/video_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Mas::Cms::Video, type: :model do
       title: 'awesome-title',
       description: 'awesome-description',
       body: 'awesome-body',
-      categories: %i(foo bar),
+      categories: %i[foo bar],
       alternates: [:cy]
     }
   end
@@ -18,7 +18,7 @@ RSpec.describe Mas::Cms::Video, type: :model do
 
   describe 'attributes' do
     it 'are set' do
-      %i(type title description body categories alternates).each do |attr|
+      %i[type title description body categories alternates].each do |attr|
         expect(subject.public_send(attr)).to eql(params[attr])
       end
     end


### PR DESCRIPTION
[TP 9202](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&searchPopup=userstory/9202)

## Description
The requirement is for a Fincap page which shows summaries of all the Thematic Reviews. This pr amends the gem which interacts with the cms.

[Related fin_cap pr](https://github.com/moneyadviceservice/fin_cap/pull/143)

### Technical
- Add the full_path attribute to the Article class. This attribute is used in fin_cap views for displaying links to specific articles, e.g. thematic reviews
- Fix rubocop offenses


