### PR TITLE
9283 latest news component for Fincap

### DIFF
--- a/lib/mas/cms/entity/article.rb
+++ b/lib/mas/cms/entity/article.rb
@@ -12,7 +12,8 @@ module Mas::Cms
                   :related_content,
                   :supports_amp,
                   :non_content_blocks,
-                  :full_path
+                  :full_path,
+                  :tags
     attr_reader :alternates
 
     ROOT_NAME = 'documents'.freeze


### PR DESCRIPTION
[TP 9283](https://moneyadviceservice.tpondemand.com/restui/board.aspx#page=board/5481321774608038243&appConfig=eyJhY2lkIjoiNjRGM0FCMDY3RUQ5MDREM0RGNDZGOUM0REZENUZBMzIifQ==&searchPopup=userstory/9283)

### REQUIREMENT
A number of FinCap pages need to show related news articles. Related news articles are those that have the same tags as the current page.

### SOLUTION
Currently, the cms and this gem do not include the tags associated with an article in the response. This pr adds the capability for tags to be accessed when passed through from the cms to fincap