### PR TITLE
[DEV APPROVED] - Enable previewing news type pages for fincap

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The gems supports the following types:
 * Home Page
 * Home Page Preview
 * News
+* News Preview
 * Video
 * Video Preview
 

--- a/lib/mas/cms.rb
+++ b/lib/mas/cms.rb
@@ -32,6 +32,7 @@ module Mas
     autoload :HomePage, 'mas/cms/entity/home_page'
     autoload :HomePagePreview, 'mas/cms/entity/home_page_preview'
     autoload :News, 'mas/cms/entity/news'
+    autoload :NewsPreview, 'mas/cms/entity/news_preview'
     autoload :NewsCollection, 'mas/cms/entity/news_collection'
     autoload :Other, 'mas/cms/entity/other'
     autoload :PageFeedback, 'mas/cms/entity/page_feedback'

--- a/lib/mas/cms/client/version.rb
+++ b/lib/mas/cms/client/version.rb
@@ -1,7 +1,7 @@
 module Mas
   module Cms
     module Client
-      VERSION = '1.16.0'.freeze
+      VERSION = '1.17.0'.freeze
     end
   end
 end

--- a/lib/mas/cms/entity/news_preview.rb
+++ b/lib/mas/cms/entity/news_preview.rb
@@ -1,0 +1,5 @@
+module Mas::Cms
+  class NewsPreview < News
+    include Mas::Cms::Preview
+  end
+end

--- a/spec/mas/cms/entity/news_preview_spec.rb
+++ b/spec/mas/cms/entity/news_preview_spec.rb
@@ -1,0 +1,10 @@
+module Mas::Cms
+  RSpec.describe NewsPreview, type: :model do
+    it_has_behavior 'a cms page entity'
+    it_has_behavior 'a cms preview page'
+
+    subject { described_class.new(double, attributes) }
+
+    it { expect(described_class.superclass).to be(Mas::Cms::News) }
+  end
+end


### PR DESCRIPTION
This pr continues the work for [TP 9186](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&searchPopup=userstory/9186)

### Context
Fincap website editors need to preview their changes/additions to Fincap News pages and the Latest News page  once a draft version has been entered into the cms, before the document is published.
