### PR TITLE
Add message when client receive errors

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -10,5 +10,11 @@ require "mas/cms/client"
 # require "pry"
 # Pry.start
 
+Mas::Cms::Client.config do |c|
+  c.timeout = 10
+  c.open_timeout = 10
+  c.host = 'http://localhost:3000/'
+end
+
 require "irb"
 IRB.start

--- a/lib/mas/cms/client/version.rb
+++ b/lib/mas/cms/client/version.rb
@@ -1,7 +1,7 @@
 module Mas
   module Cms
     module Client
-      VERSION = '1.15.0'.freeze
+      VERSION = '1.16.0'.freeze
     end
   end
 end

--- a/lib/mas/cms/connection.rb
+++ b/lib/mas/cms/connection.rb
@@ -72,7 +72,7 @@ module Mas
         when 422
           raise Errors::UnprocessableEntity
         else
-          raise Errors::ClientError
+          raise Errors::ClientError, error.message
         end
       end
 

--- a/spec/mas/cms/connection_spec.rb
+++ b/spec/mas/cms/connection_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Mas::Cms::Connection do
 
       it 'raises an `Mas::Cms::Connection::ClientError error' do
         expect { connection.post(params) }.to raise_error(
-          Mas::Cms::Errors::ClientError
+          Mas::Cms::Errors::ClientError, 'SSL_connect returned=1 errno=0'
         )
       end
     end


### PR DESCRIPTION
This makes better to figure it out what is wrong when requesting to CMS raises error like SSL problems instead of having debugging the raw connection from Faraday.