### PR TITLE
[DEV APPROVED] - [9569] Add meta_title attribute to entities

### DIFF
--- a/lib/mas/cms/entity/article.rb
+++ b/lib/mas/cms/entity/article.rb
@@ -7,6 +7,7 @@ module Mas::Cms
                   :identifier,
                   :title,
                   :description,
+                  :meta_title,
                   :body,
                   :categories,
                   :related_content,
@@ -15,6 +16,8 @@ module Mas::Cms
                   :full_path,
                   :tags
     attr_reader :alternates
+
+    alias_method :meta_description, :description
 
     ROOT_NAME = 'documents'.freeze
 

--- a/lib/mas/cms/entity/category.rb
+++ b/lib/mas/cms/entity/category.rb
@@ -1,9 +1,9 @@
 module Mas::Cms
   class Category < Entity
     include Mas::Cms::Resource
-    attr_accessor :type, :parent_id, :title, :description, :contents,
-                  :third_level_navigation, :images, :links, :category_promos,
-                  :legacy_contents, :legacy, :url_path
+    attr_accessor :type, :parent_id, :title, :description, :meta_title,
+                  :contents, :third_level_navigation, :images, :links,
+                  :category_promos, :legacy_contents, :legacy, :url_path
     validates_presence_of :title
 
     class << self

--- a/lib/mas/cms/entity/clump.rb
+++ b/lib/mas/cms/entity/clump.rb
@@ -1,7 +1,8 @@
 module Mas::Cms
   class Clump < Entity
     include Mas::Cms::Resource
-    attr_accessor :name, :description, :categories, :links
+    attr_accessor :name, :description, :meta_title,
+                  :categories, :links
     validates_presence_of :name, :description
 
     def attributes

--- a/lib/mas/cms/entity/home_page.rb
+++ b/lib/mas/cms/entity/home_page.rb
@@ -2,8 +2,8 @@ module Mas::Cms
   class HomePage < Page
     Alternate = Struct.new(:title, :url, :hreflang)
 
-    attr_accessor :type, :slug, :identifier, :title, :description, :body,
-                  :categories, :related_content, :promo,
+    attr_accessor :type, :slug, :identifier, :title, :description,
+                  :meta_title, :body, :categories, :related_content, :promo,
                   :heading, :hero_image,
                   :bullet_1, :bullet_2, :bullet_3,
                   :cta_text, :cta_link,

--- a/lib/mas/cms/entity/other.rb
+++ b/lib/mas/cms/entity/other.rb
@@ -1,5 +1,5 @@
 module Mas::Cms
   class Other < Entity
-    attr_accessor :type, :title, :description
+    attr_accessor :type, :title, :description, :meta_title
   end
 end

--- a/lib/mas/cms/entity/static_page.rb
+++ b/lib/mas/cms/entity/static_page.rb
@@ -2,8 +2,8 @@ module Mas::Cms
   class StaticPage < Entity
     Alternate = Struct.new(:title, :url, :hreflang)
 
-    attr_accessor :type, :title, :description, :body, :label, :meta_description,
-                  :translations
+    attr_accessor :type, :title, :description, :meta_title,
+                  :body, :label, :meta_description, :translations
 
     validates_presence_of :title
 

--- a/lib/mas/cms/entity/video.rb
+++ b/lib/mas/cms/entity/video.rb
@@ -2,7 +2,8 @@ module Mas::Cms
   class Video < Page
     include Mas::Cms::Resource
 
-    attr_accessor :type, :title, :description, :body, :categories, :alternates
+    attr_accessor :type, :title, :description, :meta_title,
+                  :body, :categories, :alternates
 
     validates_presence_of :title, :body
 

--- a/lib/mas/cms/repository/cms/attribute_builder.rb
+++ b/lib/mas/cms/repository/cms/attribute_builder.rb
@@ -25,6 +25,7 @@ module Mas::Cms::Repository
         group_nested_attributes(attributes)
 
         assign_description(attributes)
+        assign_meta_title(attributes)
         assign_categories(attributes)
         assign_alternates(attributes)
 
@@ -56,6 +57,10 @@ module Mas::Cms::Repository
 
       def assign_description(attributes)
         attributes['description'] = attributes['meta_description']
+      end
+
+      def assign_meta_title(attributes)
+        attributes['meta_title'] = attributes['meta_title']
       end
 
       def assign_categories(attributes)

--- a/spec/mas/cms/attribute_builder_spec.rb
+++ b/spec/mas/cms/attribute_builder_spec.rb
@@ -26,6 +26,11 @@ module Mas::Cms::Repository::CMS
         expect(subject['description']).to eq(expected)
       end
 
+      it 'returns meta_title' do
+        expected = 'How to Manage Your Money – Beginner\'s Guide'
+        expect(subject['meta_title']).to eq(expected)
+      end
+
       it 'returns categories' do
         expected = ['managing-money', 'taking-control-of-debt'].map do |category_name|
           Mas::Cms::Category.new(category_name, {})

--- a/spec/mas/cms/entity/article_spec.rb
+++ b/spec/mas/cms/entity/article_spec.rb
@@ -24,6 +24,7 @@ module Mas::Cms
       {
         title:       double,
         description: double,
+        meta_title:  double,
         slug:        double,
         body:        double,
         non_content_blocks: non_content_blocks,
@@ -285,7 +286,7 @@ module Mas::Cms
       end
     end
 
-    it { is_expected.to have_attributes(:type, :title, :description, :body, :alternates) }
+    it { is_expected.to have_attributes(:type, :title, :description, :meta_title, :body, :alternates) }
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:body) }
 
@@ -340,6 +341,16 @@ module Mas::Cms
     describe '#redirect?' do
       it 'is falsey' do
         expect(subject.redirect?).to be_falsey
+      end
+    end
+
+    describe '#meta_description' do
+      let(:attributes) do
+        { description: 'something described' }
+      end
+
+      it 'is an alias for :description' do
+        expect(subject.meta_description).to eq 'something described'
       end
     end
   end

--- a/spec/mas/cms/entity/category_spec.rb
+++ b/spec/mas/cms/entity/category_spec.rb
@@ -7,6 +7,7 @@ module Mas::Cms
         title:       double,
         parent_id:   double,
         description: double,
+        meta_title:  double,
         contents:    double,
         images:      double,
         links:       double,
@@ -15,7 +16,7 @@ module Mas::Cms
       }
     end
 
-    it { is_expected.to have_attributes(:type, :parent_id, :title, :description, :contents) }
+    it { is_expected.to have_attributes(:type, :parent_id, :title, :description, :meta_title, :contents) }
     it { is_expected.to have_attributes(:images, :links, :category_promos, :legacy_contents, :url_path) }
     it { is_expected.to validate_presence_of(:title) }
 

--- a/spec/mas/cms/entity/clump_spec.rb
+++ b/spec/mas/cms/entity/clump_spec.rb
@@ -7,12 +7,13 @@ module Mas::Cms
       {
         name:        double,
         description: double,
+        meta_title:  double,
         categories:  double,
         links:       double
       }
     end
 
-    it { is_expected.to have_attributes(:name, :description, :categories, :links) }
+    it { is_expected.to have_attributes(:name, :description, :meta_title, :categories, :links) }
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:description) }
 

--- a/spec/mas/cms/entity/corporate_spec.rb
+++ b/spec/mas/cms/entity/corporate_spec.rb
@@ -22,6 +22,7 @@ module Mas::Cms
       {
         title:       double,
         description: double,
+        meta_title:  double,
         slug:        double,
         body:        double,
         alternates:  [{ title: double, url: double, hreflang: double }],

--- a/spec/mas/cms/entity/static_page_spec.rb
+++ b/spec/mas/cms/entity/static_page_spec.rb
@@ -6,12 +6,17 @@ module Mas::Cms
       {
         title:        double,
         description:  double,
+        meta_title:   double,
         body:         double,
         translations: [{ label: double, link: double('link').as_null_object, language: double }.stringify_keys]
       }
     end
 
-    it { is_expected.to have_attributes(:type, :title, :description, :body, :label, :meta_description, :translations) }
+    it do
+      is_expected.to have_attributes(
+        :type, :title, :description, :meta_description, :body, :label, :meta_description, :translations
+      )
+    end
 
     it { is_expected.to validate_presence_of(:title) }
 

--- a/spec/mas/cms/entity/video_spec.rb
+++ b/spec/mas/cms/entity/video_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Mas::Cms::Video, type: :model do
       type: 'no-idea-about-type',
       title: 'awesome-title',
       description: 'awesome-description',
+      meta_title: 'awesome-title',
       body: 'awesome-body',
       categories: %i[foo bar],
       alternates: [:cy]


### PR DESCRIPTION
[TP Card](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=userstory/9569)

- In order for the meta information to be displayed correctly both description and meta_title have to be assigned. 

### Considerations

- To future-proof the feature I have added the meta_title to all entities having a `description`
- Tested ok for all entities types requested:
  ```
    Homepage
    Review
    Insight
    Evaluation
    Lifestage
    News
  ```