### PR TITLE
Update Jenkins to use docker-compose

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,1 @@
+danger.import_dangerfile(github: 'moneyadviceservice/mas-standards')

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,9 @@ RUN \curl -#LO https://rvm.io/mpapis.asc && gpg --import mpapis.asc && \
 RUN /bin/bash -lc "rvm requirements" && \
   /bin/bash -lc  "rvm install $(cat .ruby-version) && rvm use $(cat .ruby-version) --default"
 
-#Install Bundler
+#Install Bundler & Geminabox
 RUN /bin/bash -lc "gem install -v ${BUNDLER_VERSION} bundler"
+RUN /bin/bash -lc "gem install geminabox"
 
 #Install Node
 RUN curl https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz \

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gemspec
 
 group :test do
   gem 'bundler', '~> 1.11'
+  gem 'danger', require: false
+  gem 'danger-rubocop', require: false
   gem 'factory_girl', '~> 4.7'
   gem 'faker', '~> 1.6'
   gem 'rake', '~> 12.0'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,25 +1,43 @@
 pipeline {
-    agent {
-        dockerfile {
-            args '-u 0:0'
-        }
+    agent { label "master" }
+    environment {
+        COMPOSE_PROJECT_NAME = "${env.JOB_NAME}"
+        GITHUB_TOKEN = credentials('masbuild-github-token')
     }
-
     stages {
-        stage('Test') {
+        stage('prepare') {
+          steps {
+            sh "docker-compose -f docker-compose.yml build --force-rm"
+            sh "docker-compose -f docker-compose.yml up -d"
+          }
+        }
+        stage ('branch-test') {
+          when { not { branch 'PR-*' } }
             steps {
-                sh('./script/test')
+                sh "docker-compose -f docker-compose.yml run --rm rails ./test.sh"
             }
         }
-        stage('Build') {
-            when { branch 'master'}
-            steps {
-                sh('./script/build')
+        stage ('pr-test') {
+          when { branch 'PR-*' }
+            environment {
+              DANGER_CHANGE_ID = "${env.CHANGE_ID}"
+              DANGER_GIT_URL = "${env.GIT_URL}"
+              DANGER_JENKINS_URL = "${env.JENKINS_URL}"
             }
+            steps {
+                sh "docker-compose -f docker-compose.yml run --rm rails ./test.sh"
+            }
+        }
+        stage('build') {
+          when { branch 'master' }
+          steps {
+            sh "docker-compose -f docker-compose.yml run --rm rails ./script/build.sh"
+          }
         }
     }
     post {
         always {
+            sh 'docker-compose -f docker-compose.yml down --remove-orphans'
             cleanWs()
         }
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '2.1'
+services:
+  rails:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - GITHUB_USER=$GITHUB_TOKEN_USR
+      - GITHUB_PASS=$GITHUB_TOKEN_PSW
+      - DANGER_GITHUB_API_TOKEN=$GITHUB_TOKEN_PSW
+      - CHANGE_ID=$DANGER_CHANGE_ID
+      - GIT_URL=$DANGER_GIT_URL
+      - JENKINS_URL=$DANGER_JENKINS_URL
+      - HTTP_REQUEST_TIMEOUT=10
+      - LANG=C.UTF-8

--- a/lib/mas/cms/repository/cms/attribute_builder.rb
+++ b/lib/mas/cms/repository/cms/attribute_builder.rb
@@ -1,5 +1,4 @@
 require 'mas/cms/repository/cms/block_composer'
-
 module Mas::Cms::Repository
   module CMS
     class AttributeBuilder

--- a/mas-cms-client.gemspec
+++ b/mas-cms-client.gemspec
@@ -1,7 +1,5 @@
-# coding: utf-8
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'mas/cms/client/version'
 
 Gem::Specification.new do |spec|

--- a/spec/mas/cms/attribute_builder_spec.rb
+++ b/spec/mas/cms/attribute_builder_spec.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 require 'mas/cms/repository/cms/attribute_builder'
 
 module Mas::Cms::Repository::CMS
@@ -73,6 +71,7 @@ module Mas::Cms::Repository::CMS
       it 'body is html' do
         # rubocop:disable LineLength
         expect(subject['body']).to include('<p><strong>Good money management can mean many things – from living within your means to saving for short and long-term goals, to having a realistic plan to pay off your debts. Read on if you want to learn how to set up a budget, make the most of your money, pay off debts or start saving.</strong></p>')
+        # rubocop:enable LineLength
       end
 
       context 'when passing another options' do

--- a/test.sh
+++ b/test.sh
@@ -31,7 +31,7 @@ function info {
 }
 
 run ./bin/setup
-run bundle exec rubocop .
+run bundle exec rubocop . --fail-level error
 run bundle exec rspec
 
 if [ -f /.dockerenv ]; then

--- a/test.sh
+++ b/test.sh
@@ -1,13 +1,41 @@
 #!/bin/bash -l
 
-set -e -x
+if [ -f /.dockerenv ]; then
+    source ~/.bashrc
+    rvm use default
+    bundle config github.com $GITHUB_USER:$GITHUB_PASS
+fi
 
-export PATH=./bin:$PATH
+export RAILS_ENV=test
+export BUNDLE_WITHOUT=development:build
 
-./bin/setup
+exit_code=0
 
-CI_PIPELINE_COUNTER=${GO_PIPELINE_LABEL-0}
-CI_EXECUTOR_NUMBER=${EXECUTOR_NUMBER-0}
+function run {
+    declare -a tests_command=("$@")
+    echo ''
+    echo "=== Running \`${tests_command[*]}\`"
+    if ! ${tests_command[*]}; then
+        echo "=== These tests failed."
+        exit_code=1
+    fi
+}
 
-bundle exec rubocop .
-bundle exec rspec
+function info {
+    declare -a info_command=("$@")
+    echo ''
+    echo "=== Running for informational purposes \`${info_command[*]}\`"
+    if ! ${info_command[*]}; then
+        echo "== This test has errors and/or warnings. Please review results"
+    fi
+}
+
+run ./bin/setup
+run bundle exec rubocop .
+run bundle exec rspec
+
+if [ -f /.dockerenv ]; then
+  run bundle exec danger --verbose
+fi
+
+exit "$exit_code"


### PR DESCRIPTION
The Jenkins config is outdated in this repo. Some updates to improve test and build.

- Update the Jenkins pipelines to use docker-compose
- Set the Rubocop test fail-level to `error` until all offences resolved
- Add Danger gem