### PR TITLE
[DEV APPROVED] Remove API prefix override in Clump entity

### DIFF
--- a/lib/mas/cms/entity/clump.rb
+++ b/lib/mas/cms/entity/clump.rb
@@ -15,8 +15,6 @@ module Mas::Cms
     end
 
     class << self
-      def api_prefix; end
-
       def resource_attributes(response_body, _)
         body = response_body.dup
         body['categories'] = Array(body['categories']).map { |category| build_category(category) }

--- a/spec/mas/cms/entity/clump_spec.rb
+++ b/spec/mas/cms/entity/clump_spec.rb
@@ -5,23 +5,17 @@ module Mas::Cms
 
     let(:attributes) do
       {
-        name:        double,
+        name: double,
         description: double,
-        meta_title:  double,
-        categories:  double,
-        links:       double
+        meta_title: double,
+        categories: double,
+        links: double
       }
     end
 
     it { is_expected.to have_attributes(:name, :description, :meta_title, :categories, :links) }
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:description) }
-
-    describe '.api_prefix' do
-      it 'returns nil' do
-        expect(described_class.api_prefix).to be(nil)
-      end
-    end
 
     describe '.resource_attributes' do
       let(:entity_attrs) do


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/entity/8217-make-the-cms-clumps-api-url)

A route has been added to the CMS that exposes clumps via the path
/api/:locale/clumps, bringing the URL structure of clumps in line with
other API resources. Remove the api_prefix method override so that
CMS clients make use of the new route.

Version increment and release to follow.